### PR TITLE
Audio download buttons and proper extension handling across the app

### DIFF
--- a/riffusion/streamlit/pages/image_to_audio.py
+++ b/riffusion/streamlit/pages/image_to_audio.py
@@ -1,4 +1,5 @@
 import dataclasses
+from pathlib import Path
 
 import streamlit as st
 from PIL import Image
@@ -29,10 +30,11 @@ def render_image_to_audio() -> None:
         )
 
     device = streamlit_util.select_device(st.sidebar)
+    extension = streamlit_util.select_audio_extension(st.sidebar)
 
     image_file = st.file_uploader(
         "Upload a file",
-        type=["png", "jpg", "jpeg"],
+        type=streamlit_util.IMAGE_EXTENSIONS,
         label_visibility="collapsed",
     )
     if not image_file:
@@ -55,13 +57,17 @@ def render_image_to_audio() -> None:
     with st.expander("Spectrogram Parameters", expanded=False):
         st.json(dataclasses.asdict(params))
 
-    audio_bytes = streamlit_util.audio_bytes_from_spectrogram_image(
+    segment = streamlit_util.audio_segment_from_spectrogram_image(
         image=image.copy(),
         params=params,
         device=device,
-        output_format="mp3",
     )
-    st.audio(audio_bytes)
+
+    streamlit_util.display_and_download_audio(
+        segment,
+        name=Path(image_file.name).stem,
+        extension=extension,
+    )
 
 
 if __name__ == "__main__":

--- a/riffusion/streamlit/pages/sample_clips.py
+++ b/riffusion/streamlit/pages/sample_clips.py
@@ -6,6 +6,8 @@ import numpy as np
 import pydub
 import streamlit as st
 
+from riffusion.streamlit import util as streamlit_util
+
 
 def render_sample_clips() -> None:
     st.set_page_config(layout="wide", page_icon="🎸")
@@ -28,7 +30,7 @@ def render_sample_clips() -> None:
 
     audio_file = st.file_uploader(
         "Upload a file",
-        type=["wav", "mp3", "ogg"],
+        type=streamlit_util.AUDIO_EXTENSIONS,
         label_visibility="collapsed",
     )
     if not audio_file:
@@ -49,22 +51,26 @@ def render_sample_clips() -> None:
         )
     )
 
-    seed = T.cast(int, st.sidebar.number_input("Seed", value=42))
-    duration_ms = T.cast(int, st.sidebar.number_input("Duration (ms)", value=5000))
+    extension = streamlit_util.select_audio_extension(st.sidebar)
+    save_to_disk = st.sidebar.checkbox("Save to Disk", False)
     export_as_mono = st.sidebar.checkbox("Export as Mono", False)
-    num_clips = T.cast(int, st.sidebar.number_input("Number of Clips", value=3))
-    extension = st.sidebar.selectbox("Extension", ["mp3", "wav", "ogg"])
-    assert extension is not None
 
-    # Optionally specify an output directory
-    output_dir = st.text_input("Output Directory")
-    if not output_dir:
-        tmp_dir = tempfile.mkdtemp(prefix="sample_clips_")
-        st.info(f"Specify an output directory. Suggested: `{tmp_dir}`")
+    row = st.columns(4)
+    num_clips = T.cast(int, row[0].number_input("Number of Clips", value=3))
+    duration_ms = T.cast(int, row[1].number_input("Duration (ms)", value=5000))
+    seed = T.cast(int, row[2].number_input("Seed", value=42))
+
+    counter = streamlit_util.StreamlitCounter()
+    st.button("Sample Clips", type="primary", on_click=counter.increment)
+    if counter.value == 0:
         return
 
-    output_path = Path(output_dir)
-    output_path.mkdir(parents=True, exist_ok=True)
+    # Optionally pick an output directory
+    if save_to_disk:
+        output_dir = tempfile.mkdtemp(prefix="sample_clips_")
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+        st.info(f"Output directory: `{output_dir}`")
 
     if seed >= 0:
         np.random.seed(seed)
@@ -78,16 +84,22 @@ def render_sample_clips() -> None:
         clip_start_ms = np.random.randint(0, segment_duration_ms - duration_ms)
         clip = segment[clip_start_ms : clip_start_ms + duration_ms]
 
-        clip_name = f"clip_{i}_start_{clip_start_ms}_ms_duration_{duration_ms}_ms.{extension}"
+        clip_name = f"clip_{i}_start_{clip_start_ms}_ms_duration_{duration_ms}_ms"
 
         st.write(f"#### Clip {i + 1} / {num_clips} -- `{clip_name}`")
 
-        clip_path = output_path / clip_name
-        clip.export(clip_path, format=extension)
+        streamlit_util.display_and_download_audio(
+            clip,
+            name=clip_name,
+            extension=extension,
+        )
 
-        st.audio(str(clip_path))
+        if save_to_disk:
+            clip_path = output_path / f"clip_name.{extension}"
+            clip.export(clip_path, format=extension)
 
-    st.info(f"Wrote {num_clips} clip(s) to `{str(output_path)}`")
+    if save_to_disk:
+        st.info(f"Wrote {num_clips} clip(s) to `{str(output_path)}`")
 
 
 if __name__ == "__main__":

--- a/riffusion/streamlit/pages/text_to_audio.py
+++ b/riffusion/streamlit/pages/text_to_audio.py
@@ -27,6 +27,7 @@ def render_text_to_audio() -> None:
         )
 
     device = streamlit_util.select_device(st.sidebar)
+    extension = streamlit_util.select_audio_extension(st.sidebar)
 
     with st.form("Inputs"):
         prompt = st.text_input("Prompt")
@@ -87,13 +88,15 @@ def render_text_to_audio() -> None:
         )
         st.image(image)
 
-        audio_bytes = streamlit_util.audio_bytes_from_spectrogram_image(
+        segment = streamlit_util.audio_segment_from_spectrogram_image(
             image=image,
             params=params,
             device=device,
-            output_format="mp3",
         )
-        st.audio(audio_bytes)
+
+        streamlit_util.display_and_download_audio(
+            segment, name=f"{prompt.replace(' ', '_')}_{seed}", extension=extension
+        )
 
         seed += 1
 

--- a/riffusion/streamlit/playground.py
+++ b/riffusion/streamlit/playground.py
@@ -13,13 +13,13 @@ def render_main():
         st.write("Generate audio clips from text prompts.")
 
         create_link(":wave: Audio to Audio", "/audio_to_audio")
-        st.write("Upload audio and modify with text prompt.")
+        st.write("Upload audio and modify with text prompt (interpolation supported).")
 
         create_link(":performing_arts: Interpolation", "/interpolation")
         st.write("Interpolate between prompts in the latent space.")
 
         create_link(":scissors: Audio Splitter", "/split_audio")
-        st.write("Upload audio and split into vocals, bass, drums, and other.")
+        st.write("Split audio into stems like vocals, bass, drums, guitar, etc.")
 
     with right:
         create_link(":scroll: Text to Audio Batch", "/text_to_audio_batch")

--- a/riffusion/util/audio_util.py
+++ b/riffusion/util/audio_util.py
@@ -83,3 +83,17 @@ def stitch_segments(
     for segment in segments[1:]:
         combined_segment = combined_segment.append(segment, crossfade=crossfade_ms)
     return combined_segment
+
+
+def overlay_segments(segments: T.Sequence[pydub.AudioSegment]) -> pydub.AudioSegment:
+    """
+    Overlay a sequence of audio segments on top of each other.
+    """
+    assert len(segments) > 0
+    output: pydub.AudioSegment = None
+    for segment in segments:
+        if output is None:
+            output = segment
+        else:
+            output = output.overlay(segment)
+    return output


### PR DESCRIPTION
* Add buttons that download audio segments with the proper name, and display the name
 * Add a helper that displays the audio bar and the download button
 * Create a sidebar widget helper for choosing the output extension
 * Use this extension widget in all pages to dicate output types
 * Add a streamlit session state counter object to help with reruns
 * Improve UI in various places with small fixes

Topic: audio_download_extensions_ui