### PR TITLE
Make it possible to run the playground directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Riffusion contains a [streamlit](https://streamlit.io/) app for interactive use 
 
 Run with:
 ```
-python -m streamlit run riffusion/streamlit/playground.py --browser.serverAddress 127.0.0.1 --browser.serverPort 8501
+python -m riffusion.streamlit.playground
 ```
 
 And access at http://127.0.0.1:8501/

--- a/riffusion/streamlit/playground.py
+++ b/riffusion/streamlit/playground.py
@@ -1,4 +1,8 @@
+import sys
+
 import streamlit as st
+import streamlit.web.cli as stcli
+from streamlit import runtime
 
 PAGES = {
     "🎛️ Home": "tasks.home",
@@ -12,7 +16,7 @@ PAGES = {
 }
 
 
-def main() -> None:
+def render() -> None:
     st.set_page_config(
         page_title="Riffusion Playground",
         page_icon="🎸",
@@ -26,4 +30,8 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    if runtime.exists():
+        render()
+    else:
+        sys.argv = ["streamlit", "run"] + sys.argv
+        sys.exit(stcli.main())


### PR DESCRIPTION
It can now be run with:

    python -m streamlit run riffusion/streamlit/playground.py
    python riffusion/streamlit/playground.py
    python -m riffusion.streamlit.playground

Which adds a ton of flexibility.