### PR TITLE
Pin diffusers version to 0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate
 argh
 dacite
 demucs
-diffusers>=0.9.0
+diffusers==0.9.0
 flask
 flask_cors
 numpy


### PR DESCRIPTION
Thanks for this great project!

## Problem

I was not able to get my server running locally, initially. I followed these steps:

```
virtualenv venv && source venv/bin/activate
pip install -r requirements.txt
```

And got this error:

```
  File "/Users/veeralpatel/dev/riffusion2/riffusion/riffusion_pipeline.py", line 14, in <module>
    from diffusers.pipeline_utils import DiffusionPipeline
ModuleNotFoundError: No module named 'diffusers.pipeline_utils'
```

## Solution

I noticed `pip` is installing `diffusers` 0.24.0. I browsed the `diffusers` code. Looks like they refactored. We need to import `DiffusionPipeline` like this now:

```
from diffusers import DiffusionPipeline
# or
from diffusers.pipelines import DiffusionPipeline
```

I've just pinned `diffusers` to `0.9.0` which gets my server running fine.

```
(venv) riffusion git:main ❯ python -m riffusion.server --host 127.0.0.1 --port 3013                       ✹
/Users/veeralpatel/dev/riffusion3/riffusion/server.py:55: UserWarning: WARNING: cuda is not available, using cpu instead.
  PIPELINE = RiffusionPipeline.load_checkpoint(
WARNING: Falling back to float32 on cpu, float16 is unsupported
Fetching 15 files:   0%|                                                             | 0/15 [00:00<?, ?it/s^Fetching 15 files:  20%|██████████▌                                          | 3/15 [00:01<00:07,  1.57it/s]
``` 